### PR TITLE
security: override handlebars + basic-ftp to patched versions (critical)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,101 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+A **pnpm + Turborepo monorepo** (`ustrs`) containing two React apps and shared libraries. Package manager is `pnpm@9.9.0`. Node version is `20.17.0` (managed via Volta).
+
+## Repository Structure
+
+```
+apps/
+  businessbynumbers/  (package: "bbn") — React app with Auth0 + Apollo/GraphQL
+  grainbygrain/       (package: "grain-by-grain") — React app with Nhost + Apollo/GraphQL + react-router-dom
+libs/
+  shadcn-ui/          (package: "@ustrs/shadcn-ui") — Shared Vite-built React component library using Tailwind
+  utils/              (package: "@ustrs/utils") — Shared TypeScript utility types
+  typescript-config/  (package: "@ustrs/typescript-config") — Shared tsconfig base configs
+turbo/generators/     — Turborepo plop generators for scaffolding new apps/libs
+```
+
+## Common Commands
+
+All commands are run from the monorepo root unless noted.
+
+### Development
+```bash
+pnpm dev:bbn          # Dev server for businessbynumbers (+ its lib deps)
+```
+
+### Building
+```bash
+pnpm build:all        # Build everything
+pnpm build:bbn        # Build businessbynumbers only
+```
+
+### Testing
+```bash
+pnpm test:bbn         # Run bbn tests once
+pnpm test:ui          # Run @ustrs/shadcn-ui tests once
+pnpm test:watch:bbn   # Watch mode for bbn
+pnpm test:watch:ui    # Watch mode for @ustrs/shadcn-ui
+```
+
+To run a single test file, use the package's test runner directly:
+```bash
+pnpm --filter=bbn exec vitest run src/components/App/index.test.tsx
+```
+
+### Linting & Formatting
+```bash
+pnpm lint             # ESLint across all apps and libs
+pnpm lint:fix         # Auto-fix lint issues
+pnpm format           # Prettier format all source files
+```
+
+### Storybook
+```bash
+pnpm storybook:ui     # Run Storybook for @ustrs/shadcn-ui on port 6006
+```
+
+### Scaffolding
+```bash
+pnpm gen              # Interactive Turborepo generator to scaffold new app or lib
+```
+
+### GraphQL Codegen (grain-by-grain only)
+```bash
+pnpm --filter=grain-by-grain codegen   # Regenerate types from GraphQL schema into src/gql/
+```
+
+## Architecture
+
+### Turborepo Pipeline
+Build tasks run in dependency order (`^build`). Libraries must be built before apps consume them. The `dev` task for `bbn` also builds `@ustrs/utils` and `@ustrs/shadcn-ui` in watch mode.
+
+### @ustrs/shadcn-ui Library
+- Vite-built, exports components + two additional exports:
+  - `@ustrs/shadcn-ui/styles` — processed Tailwind CSS, must be imported in consumer app entry point
+  - `@ustrs/shadcn-ui/tailwind.preset` — shared Tailwind config preset for consumer apps
+- Uses a `ui-` prefix for Tailwind classes to avoid collisions with consuming app classes
+- Components live in `libs/shadcn-ui/src/components/ui/`
+
+### businessbynumbers (bbn)
+- Auth: Auth0 via `@auth0/auth0-react`
+- Data: Apollo Client + GraphQL
+- Path alias `@/` maps to `src/` (via `vite-tsconfig-paths`)
+- Tests: Vitest + jsdom + `@testing-library/react`; custom render wrapper in `src/test/utils.ts`
+
+### grain-by-grain
+- Auth: Nhost via `@nhost/react`
+- Data: Apollo Client with Nhost integration (`@nhost/apollo`)
+- Routing: `react-router-dom` with routes in `src/routes/` (one folder per route)
+- GraphQL types auto-generated into `src/gql/` via `@graphql-codegen/client-preset`
+- No test setup (no vitest config)
+- shadcn/ui components are **vendored directly** into `src/components/ui/` (not from the shared lib)
+
+### Code Style
+- Prettier: single quotes, no semicolons, 100 char print width, trailing commas, Tailwind plugin
+- ESLint: TypeScript + React + import ordering; `no-alert` is an error; `react-hooks/exhaustive-deps` is off
+- Pre-commit hook runs `lint`, `format`, and `syncpack lint` on staged files via lint-staged

--- a/package.json
+++ b/package.json
@@ -63,7 +63,9 @@
       }
     },
     "overrides": {
-      "express>body-parser": "^1.20.3"
+      "express>body-parser": "^1.20.3",
+      "handlebars": ">=4.7.9",
+      "basic-ftp": ">=5.2.0"
     }
   },
   "private": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,8 @@ settings:
 
 overrides:
   express>body-parser: ^1.20.3
+  handlebars: '>=4.7.9'
+  basic-ftp: '>=5.2.0'
 
 importers:
 
@@ -3939,8 +3941,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  basic-ftp@5.0.4:
-    resolution: {integrity: sha512-8PzkB0arJFV4jJWSGOYR+OEic6aeKMu/osRhBULN6RY0ykby6LKhbmuQ5ublvaas5BOwboah5D87nrHyuh8PPA==}
+  basic-ftp@5.2.0:
+    resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
     engines: {node: '>=10.0.0'}
 
   better-opn@3.0.2:
@@ -5213,8 +5215,8 @@ packages:
     resolution: {integrity: sha512-4haO1M4mLO91PW57BMsDFf75UmwoRX0GkdD+Faw+Lr+r/OZrOCS0pIBwOL1xCKQqnQzbNFGgK2V2CpBUPeFNTw==}
     hasBin: true
 
-  handlebars@4.7.8:
-    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
     engines: {node: '>=0.4.7'}
     hasBin: true
 
@@ -11426,7 +11428,7 @@ snapshots:
       find-up: 5.0.0
       fs-extra: 11.2.0
       glob: 10.3.10
-      handlebars: 4.7.8
+      handlebars: 4.7.9
       lazy-universal-dotenv: 4.0.0
       node-fetch: 2.7.0
       picomatch: 2.3.1
@@ -12663,7 +12665,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  basic-ftp@5.0.4: {}
+  basic-ftp@5.2.0: {}
 
   better-opn@3.0.2:
     dependencies:
@@ -14124,7 +14126,7 @@ snapshots:
 
   get-uri@6.0.2:
     dependencies:
-      basic-ftp: 5.0.4
+      basic-ftp: 5.2.0
       data-uri-to-buffer: 6.0.1
       debug: 4.3.4
       fs-extra: 8.1.0
@@ -14292,7 +14294,7 @@ snapshots:
       pumpify: 1.5.1
       through2: 2.0.5
 
-  handlebars@4.7.8:
+  handlebars@4.7.9:
     dependencies:
       minimist: 1.2.8
       neo-async: 2.6.2
@@ -15251,7 +15253,7 @@ snapshots:
       change-case: 3.1.0
       del: 5.1.0
       globby: 10.0.2
-      handlebars: 4.7.8
+      handlebars: 4.7.9
       inquirer: 7.3.3
       isbinaryfile: 4.0.10
       lodash.get: 4.4.2


### PR DESCRIPTION
## Summary
- Adds `pnpm.overrides` for `handlebars>=4.7.9` — fixes **1 critical** (JS Injection via AST Type Confusion) + **5 high/moderate** CVEs
- Adds `pnpm.overrides` for `basic-ftp>=5.2.0` — fixes **1 critical** CVE (Path Traversal in `downloadToDir()`)

Both are transitive dependencies in `pnpm-lock.yaml`. Overrides are the correct mechanism for forcing patched versions of transitive deps in a pnpm monorepo.

## Test plan
- [x] `pnpm install` — lock file regenerated, both packages pinned to patched versions
- [x] `pnpm build:all` — all 4 workspaces build successfully
- [x] `pnpm test:bbn` — 1 test passing
- [x] `pnpm test:ui` — 1 test passing
- [x] CI (`verify-on-pr.yml`) must pass

Part of a series of security PRs to resolve 92 Dependabot alerts.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)